### PR TITLE
#8 顧客管理画面にアクセスするとホワイトアウト原因の修正

### DIFF
--- a/frontend/src/pages/customer/CustomersPage.tsx
+++ b/frontend/src/pages/customer/CustomersPage.tsx
@@ -31,13 +31,20 @@ const CustomersPage = () => {
   const [page, setPage] = useState(0);
 
   const [rowsPerPage, setRowsPerPage] = useState<number>(() => {
-    const stored = localStorage.getItem(CUSTOMER_PAGE_SETTINGS_STORAGE_KEY)!;
-    const parsed = JSON.parse(stored) as CustomerPageSettings;
-    if (
-      typeof parsed.rowsPerPage === 'number' &&
-      VALID_PAGE_SIZES.includes(parsed.rowsPerPage as ValidPageSize)
-    ) {
-      return parsed.rowsPerPage;
+    const stored = localStorage.getItem(CUSTOMER_PAGE_SETTINGS_STORAGE_KEY);
+    if (!stored) {
+      return DEFAULT_SETTINGS.rowsPerPage;
+    }
+    try {
+      const parsed = JSON.parse(stored) as CustomerPageSettings;
+      if (
+        typeof parsed.rowsPerPage === 'number' &&
+        VALID_PAGE_SIZES.includes(parsed.rowsPerPage as ValidPageSize)
+      ) {
+        return parsed.rowsPerPage;
+      }
+    } catch (error) {
+      console.error('Failed to parse customer page settings:', error);
     }
     return DEFAULT_SETTINGS.rowsPerPage;
   });


### PR DESCRIPTION
<!-- 必要に応じて変更してください -->

## Issue の URL

https://github.com/buysell-technologies/summer-internship-2025-0909-c/issues/8

## やったこと

プロンプトを投げてAIagentに原因の特定、修正をしてもらった

### 原因
```CustomerPage.tsx``` 33行目の ```localStorage.getItem()``` が ```null``` を返す場合（初回アクセス時）に ```JSON.parse(stored)```の引数に `null` が与えられて実行されることでエラーが発生し、ページがホワイトアウトしていた。

### 与えたプロンプト
```
このコンテキストで http://127.0.0.1:5174/customers にアクセスするとホワイトアウトする原因はフロントエンドにありますか？
アプリの起動はREADMEを見てください
```

### 与えたコンテキスト
```README.md``` ```router.tsx``` ```StockPage.tsx```

## やらないこと

<!-- この PR でやらないことを書いてください -->
- データベースの中身がないことの修正

## 動作確認観点

<img width="1699" height="997" alt="スクリーンショット 2025-09-09 115227" src="https://github.com/user-attachments/assets/bbb711ab-ea45-4ea2-899a-d00f6004e255" />


- [ ] セルフレビューを十分行い、Reviews を選択した
