### PR TITLE
在庫管理のCUD実装

### DIFF
--- a/frontend/src/features/stock/components/StockDeleteDialog.tsx
+++ b/frontend/src/features/stock/components/StockDeleteDialog.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  CircularProgress,
+} from '@mui/material';
+
+interface StockDeleteDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => Promise<void>;
+  stockName?: string;
+  isLoading?: boolean;
+}
+
+const StockDeleteDialog: React.FC<StockDeleteDialogProps> = ({
+  open,
+  onClose,
+  onConfirm,
+  stockName,
+  isLoading = false,
+}) => {
+  const handleConfirm = async () => {
+    try {
+      await onConfirm();
+      onClose();
+    } catch (error) {
+      // エラーは親コンポーネントで処理
+      console.error('Delete confirmation error:', error);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>削除しますか？</DialogTitle>
+      <DialogContent>
+        <Typography>
+          {stockName ? `「${stockName}」の` : ''}
+          入力内容が削除されます。よろしいですか？
+        </Typography>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} disabled={isLoading}>
+          いいえ
+        </Button>
+        <Button
+          onClick={handleConfirm}
+          variant="contained"
+          color="error"
+          disabled={isLoading}
+          startIcon={isLoading ? <CircularProgress size={20} /> : null}
+        >
+          はい
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default StockDeleteDialog;

--- a/frontend/src/features/stock/components/StockFormModal.tsx
+++ b/frontend/src/features/stock/components/StockFormModal.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  Box,
+  CircularProgress,
+} from '@mui/material';
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  stockFormSchema,
+  type StockFormData,
+} from '../schemas/StockFormSchema';
+import type { ModelStock } from '../../../api/generated/model';
+
+interface StockFormModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (data: StockFormData) => Promise<void>;
+  stock?: ModelStock | null;
+  isLoading?: boolean;
+}
+
+const StockFormModal: React.FC<StockFormModalProps> = ({
+  open,
+  onClose,
+  onSubmit,
+  stock,
+  isLoading = false,
+}) => {
+  const isEdit = !!stock;
+  const title = isEdit ? '編集' : '登録';
+  const submitButtonText = isEdit ? '更新する' : '登録する';
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<StockFormData>({
+    resolver: zodResolver(stockFormSchema),
+    defaultValues: {
+      name: stock?.name || '',
+      price: stock?.price || 0,
+      quantity: stock?.quantity || 0,
+    },
+  });
+
+  // モーダルが開かれた時にフォームをリセット
+  React.useEffect(() => {
+    if (open) {
+      reset({
+        name: stock?.name || '',
+        price: stock?.price || 0,
+        quantity: stock?.quantity || 0,
+      });
+    }
+  }, [open, stock, reset]);
+
+  const handleFormSubmit = async (data: StockFormData) => {
+    try {
+      await onSubmit(data);
+      onClose();
+    } catch (error) {
+      // エラーは親コンポーネントで処理
+      console.error('Form submission error:', error);
+    }
+  };
+
+  const handleCancel = () => {
+    reset();
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={handleCancel} maxWidth="sm" fullWidth>
+      <DialogTitle>{title}</DialogTitle>
+      <form onSubmit={handleSubmit(handleFormSubmit)}>
+        <DialogContent>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
+            <Controller
+              name="name"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  label="商品名"
+                  fullWidth
+                  error={!!errors.name}
+                  helperText={errors.name?.message}
+                  disabled={isLoading}
+                />
+              )}
+            />
+            <Controller
+              name="price"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  label="価格"
+                  type="number"
+                  fullWidth
+                  error={!!errors.price}
+                  helperText={errors.price?.message}
+                  disabled={isLoading}
+                  onChange={(e) => field.onChange(Number(e.target.value))}
+                />
+              )}
+            />
+            <Controller
+              name="quantity"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  label="在庫数"
+                  type="number"
+                  fullWidth
+                  error={!!errors.quantity}
+                  helperText={errors.quantity?.message}
+                  disabled={isLoading}
+                  onChange={(e) => field.onChange(Number(e.target.value))}
+                />
+              )}
+            />
+          </Box>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={handleCancel} disabled={isLoading}>
+            キャンセル
+          </Button>
+          <Button
+            type="submit"
+            variant="contained"
+            disabled={isLoading}
+            startIcon={isLoading ? <CircularProgress size={20} /> : null}
+          >
+            {submitButtonText}
+          </Button>
+        </DialogActions>
+      </form>
+    </Dialog>
+  );
+};
+
+export default StockFormModal;

--- a/frontend/src/features/stock/components/StockTable.tsx
+++ b/frontend/src/features/stock/components/StockTable.tsx
@@ -21,6 +21,8 @@ interface StockTableProps {
   rowsPerPage: number;
   onPageChange: (event: unknown, newPage: number) => void;
   onRowsPerPageChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onEdit?: (stock: ModelStock) => void;
+  onDelete?: (stock: ModelStock) => void;
 }
 
 const StockTable = ({
@@ -29,6 +31,8 @@ const StockTable = ({
   rowsPerPage,
   onPageChange,
   onRowsPerPageChange,
+  onEdit,
+  onDelete,
 }: StockTableProps) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -49,29 +53,32 @@ const StockTable = ({
     if (isMobile) {
       return {
         id: '10%',
-        name: '35%',
-        price: '20%',
-        quantity: '15%',
-        created: '0%', // モバイルでは非表示
-        updated: '20%',
-      };
-    } else if (isTablet) {
-      return {
-        id: '8%',
         name: '30%',
         price: '18%',
         quantity: '12%',
-        created: '16%',
-        updated: '16%',
+        created: '0%', // モバイルでは非表示
+        updated: '20%',
+        actions: '10%',
       };
-    } else {
+    } else if (isTablet) {
       return {
-        id: '8%',
+        id: '7%',
         name: '25%',
         price: '15%',
         quantity: '10%',
-        created: '21%',
-        updated: '21%',
+        created: '13%',
+        updated: '13%',
+        actions: '7%',
+      };
+    } else {
+      return {
+        id: '6%',
+        name: '20%',
+        price: '12%',
+        quantity: '8%',
+        created: '18%',
+        updated: '18%',
+        actions: '8%',
       };
     }
   };
@@ -161,6 +168,18 @@ const StockTable = ({
             >
               更新日時
             </TableCell>
+            <TableCell
+              align="center"
+              sx={{
+                width: columnWidths.actions,
+                fontWeight: 600,
+                fontSize: '0.875rem',
+                py: 2,
+                color: '#555',
+              }}
+            >
+              操作
+            </TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -170,6 +189,8 @@ const StockTable = ({
               stock={stock}
               columnWidths={columnWidths}
               isMobile={isMobile}
+              onEdit={onEdit}
+              onDelete={onDelete}
             />
           ))}
         </TableBody>

--- a/frontend/src/features/stock/components/StockTableRow.tsx
+++ b/frontend/src/features/stock/components/StockTableRow.tsx
@@ -1,4 +1,5 @@
-import { TableRow, TableCell } from '@mui/material';
+import { TableRow, TableCell, IconButton, Tooltip, Box } from '@mui/material';
+import { Edit, Delete } from '@mui/icons-material';
 import type { ModelStock } from '../../../api/generated/model';
 import { useI18n } from '../../../providers/I18nProvider';
 
@@ -13,12 +14,16 @@ interface StockTableRowProps {
     updated: string;
   };
   isMobile: boolean;
+  onEdit?: (stock: ModelStock) => void;
+  onDelete?: (stock: ModelStock) => void;
 }
 
 const StockTableRow = ({
   stock,
   columnWidths,
   isMobile,
+  onEdit,
+  onDelete,
 }: StockTableRowProps) => {
   const { formatDate } = useI18n();
 
@@ -119,6 +124,37 @@ const StockTableRow = ({
         }}
       >
         {formatDate(stock.updated_at) || '-'}
+      </TableCell>
+      <TableCell
+        sx={{
+          py: 1.5,
+          width: '120px',
+        }}
+      >
+        <Box sx={{ display: 'flex', gap: 1, justifyContent: 'center' }}>
+          {onEdit && (
+            <Tooltip title="編集">
+              <IconButton
+                size="small"
+                onClick={() => onEdit(stock)}
+                sx={{ color: '#1976d2' }}
+              >
+                <Edit fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          )}
+          {onDelete && (
+            <Tooltip title="削除">
+              <IconButton
+                size="small"
+                onClick={() => onDelete(stock)}
+                sx={{ color: '#d32f2f' }}
+              >
+                <Delete fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          )}
+        </Box>
       </TableCell>
     </TableRow>
   );

--- a/frontend/src/features/stock/schemas/StockFormSchema.ts
+++ b/frontend/src/features/stock/schemas/StockFormSchema.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+export const stockFormSchema = z.object({
+  name: z
+    .string()
+    .min(1, '商品名は必須です')
+    .max(100, '商品名は100文字以内で入力してください'),
+  price: z
+    .number()
+    .min(0, '価格は0円以上で入力してください')
+    .int('価格は整数で入力してください'),
+  quantity: z
+    .number()
+    .min(0, '在庫数は0個以上で入力してください')
+    .int('在庫数は整数で入力してください'),
+});
+
+export type StockFormData = z.infer<typeof stockFormSchema>;

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -19,6 +19,7 @@ interface JWTPayload {
 interface AuthContextType {
   token: string | null;
   userId: string | null;
+  storeId: string | null;
   login: (token: string) => void;
   logout: () => void;
   isAuthenticated: boolean;
@@ -63,9 +64,20 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
     }
   }, [token]);
 
+  const storeId = useMemo(() => {
+    if (!token) return null;
+    try {
+      const decoded = jwtDecode<JWTPayload>(token);
+      return decoded.store_id;
+    } catch {
+      return null;
+    }
+  }, [token]);
+
   const value = {
     token,
     userId,
+    storeId,
     login,
     logout,
     isAuthenticated: !!token,


### PR DESCRIPTION
<!-- 必要に応じて変更してください -->

## Issue の URL

https://github.com/buysell-technologies/summer-internship-2025-0909-c/issues/3

## やったこと

在庫管理機能の作成・編集・削除処理
zodによるフォームバリデーション
react-hook-formによるフォーム実装

プロンプト(Cursor使用)
在庫管理ページの登録・編集・削除機能を実装します。

【新規登録】
- 「新規登録」ボタンから入力フォームを表示
- 入力フォームはモーダルとして画面に表示
- 入力フォームモーダルのタイトルは「登録」, 下部ボタンは「登録する」と「キャンセル」
-  入力フォームの必須項目: 商品名（1-100文字）、価格（0円以上）、在庫数（0個以上）
- バリデーションエラー時は適切なメッセージを表示
- 登録後は一覧に即座に反映

【編集機能】
- 各行に「編集」ボタンを配置
- 現在値を初期表示した編集フォーム
- 登録機能と同じバリデーションルール
- 更新後は一覧に即座に反映

【削除機能】
- 各行に「削除」ボタンを配置
- 確認ダイアログ表示
- ダイアログのタイトルは「削除しますか？」, 本文は「入力内容が削除されます。よろしいですか？」, 下部ボタンは「いいえ」と「はい」
- 削除後は一覧から即座に除外

【共通UI/UX】
- 処理中はボタンを無効化
- 成功・エラー時は適切なメッセージ表示
- キャンセル機能あり
- レスポンス時間3秒以内

【注意】
- クライアントのリクエスト関数はfrontend/src/api/generated/api.tsに実装されているのでそれを利用してください
- フォームの実装にはreact-hook-formを用いてください
- フォームのバリデーションにはzodを利用してください
- MUIとの連携にはreact-hook-formのControllerを使う必要があるかもしれません

## やらないこと

StockドメインのUnit TestはIssue https://github.com/buysell-technologies/summer-internship-2025-0909-c/issues/5 で行うので、テストは実装しない

## 動作確認観点

<!-- 正常な動作を保証する画像や動画を貼ってください -->

- [x] セルフレビューを十分行い、Reviews を選択した
