### PR TITLE
fix: 在庫更新時のリクエストに数値バリデーションの追加

### DIFF
--- a/server/api/handler/request/stock.go
+++ b/server/api/handler/request/stock.go
@@ -24,8 +24,8 @@ type CreateBulkStockRequest struct {
 type UpdateStockRequest struct {
 	StockID  string `param:"id" validate:"required,numeric,gt=0" example:"1" swaggerignore:"true"`
 	Name     string `json:"name" validate:"required,min=1,max=255" example:"LOUIS VUITTON M41524 ブラウン モノグラム ハンドバッグ"`
-	Quantity int    `json:"quantity" validate:"required,numeric" example:"1"`
-	Price    int    `json:"price" validate:"required,numeric" example:"100000"`
+	Quantity int    `json:"quantity" validate:"required,numeric,gte=0" example:"1" minimum:"0"`
+	Price    int    `json:"price" validate:"required,numeric,gte=0" example:"100000" minimum:"0"`
 	StoreID  string `json:"store_id" validate:"required,uuid4" example:"00000000-0000-0000-0000-000000000000"`
 	UserID   string `json:"user_id" validate:"required,uuid4" example:"00000000-0000-0000-0000-000000000000"`
 }


### PR DESCRIPTION
<!-- 必要に応じて変更してください -->

## Issue の URL

<!-- https://github.com/your-organization/your-repository/issues/your-issue-number のリンクを貼ってください-->
Closes #11 

## やったこと

<!-- 対応したバグ・改善要望に対してどのような変更を加えたか説明をお願いします -->
- 在庫更新時のリクエスト(UpdateStockRequest)にgo-playground/validatorによる数値バリデーションの追加

## やらないこと

<!-- この PR でやらないことを書いてください -->

## 動作確認観点

<!-- 正常な動作を保証する画像や動画を貼ってください -->
<img width="822" height="135" alt="スクリーンショット 2025-09-09 午後2 48 23" src="https://github.com/user-attachments/assets/a5f7c3c9-8bcb-44a9-b087-2c9fe996fd03" />

- [ ] セルフレビューを十分行い、Reviews を選択した
